### PR TITLE
DPI-2859 Package flipAPI in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,37 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipAPI";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = "Functions to extract data and interact with web APIs.";
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    flipU
+    jsonlite
+    httr
+    flipTransformations
+    flipTime
+    zip
+    flipFormat
+    odbc
+    gganimate
+    knitr
+    mime
+    stringr
+    readxl
+    rhtmlMetro
+    arrow
+    RMySQL
+    lubridate
+    zeallot
+    DBI
+    RGoogleAnalytics
+    RPostgres
+    RJSONIO
+    haven
+    openxlsx
+    rgeolocate
+    curl
+    git2r
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipAPI in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR