### PR TITLE
SS-1154: Add document.token parameter to file functions.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Suggests:
     httptest,
     officer,
     gifski
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     stringr,
     readxl,
     utils,
-    flipFormat,
     flipTime,
     flipTransformations,
     flipU (>= 1.6.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipAPI
 Type: Package
 Title: Web APIs tools
-Version: 1.6.0
+Version: 1.6.5
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions to extract data and interact with web APIs.

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -516,7 +516,7 @@ getProjectSecret <- function()
     # but it could have been stored by QServer in user secrets which are copied into userSecrets by older R servers.
     if (secret == "") {
         secret <- tryCatch({
-            val <- userSecrets$projectSecret
+            val <- .GlobalEnv$userSecrets$projectSecret
             if (is.character(val) && nzchar(val)) val else ""
         },
         error = function(e) "")

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -265,7 +265,7 @@ QLoadData <- function(filename, company.token = NA, document.token = NA,...)
 #' (in bytes) larger than this value will be compressed into a zip file.
 #' Defaults to NULL, in which case no compression occurs.
 #' @param ... Other parameters to pass to \code{\link{write.csv}}, \code{\link{saveRDS}},
-#' \code{\link{write.xlsx}}, or \code{\link{write_sav}}.
+#' \code{\link[openxlsx]{write.xlsx}}, or \code{\link[haven]{write_sav}}.
 #'
 #' @importFrom haven write_sav
 #' @importFrom httr POST add_headers upload_file

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -507,7 +507,7 @@ getCompanySecret <- function()
     return (secret)
 }
 
-#' Gets document secret from the environment. Throws an error if not found.
+#' Gets document secret from the environment or an empty string if not found.
 #'
 #' @return Document secret token as a string.
 #'

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -8,6 +8,8 @@ MAX.FILENAME.LENGTH <- 100L
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #' @param show.warning logical scalar. Whether to show a warning when the file
 #'   does not exist.
+#' @param company.token Use this if you need to access a different company's Displayr Cloud Drive. You need to contact Support to get this token.
+#' @param document.token Reserved
 #'
 #' @return TRUE if the file exists, otherwise FALSE.
 #'
@@ -56,6 +58,7 @@ QFileExists <- function(filename, show.warning = TRUE, company.token = NA, docum
 #' @param method character string. See documentation for connections.
 #' @param mime.type character string. The mime-type of this file. If not provided, it will be interpreted from the file extension.
 #' @param company.token Use this if you need to read from a different company's Displayr Cloud Drive. You need to contact Support to get this token.
+#' @param document.token Reserved
 #'
 #' @return A curl connection (read) or a file connection (write)
 #'
@@ -184,6 +187,7 @@ close.qpostcon = function(con, ...)
 #' @param filename character string. Name of the file to be opened from the Displayr Cloud Drive.
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #' @param company.token Use this if you need to read from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.
+#' @param document.token Reserved
 #' @param ... Other parameters to pass to read.csv.
 #'
 #' @return An R object
@@ -379,6 +383,7 @@ QSaveData <- function(object, filename, compression.file.size.threshold = NULL,
 #' @param filenames collection of character strings. Names of the files to delete.
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #' @param company.token Use this if you need to delete files from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.
+#' @param document.token Reserved
 #'
 #' @importFrom httr DELETE add_headers
 #' @importFrom utils URLencode

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -9,7 +9,7 @@ MAX.FILENAME.LENGTH <- 100L
 #' @param show.warning logical scalar. Whether to show a warning when the file
 #'   does not exist.
 #' @param company.token Use this if you need to access a different company's Displayr Cloud Drive. You need to contact Support to get this token.
-#' @param document.token Reserved
+#' @param document.token Reserved.
 #'
 #' @return TRUE if the file exists, otherwise FALSE.
 #'
@@ -58,7 +58,7 @@ QFileExists <- function(filename, show.warning = TRUE, company.token = NA, docum
 #' @param method character string. See documentation for connections.
 #' @param mime.type character string. The mime-type of this file. If not provided, it will be interpreted from the file extension.
 #' @param company.token Use this if you need to read from a different company's Displayr Cloud Drive. You need to contact Support to get this token.
-#' @inheritParams QFileExists params = c("document.token")
+#' @inheritParams QFileExists
 #'
 #' @return A curl connection (read) or a file connection (write)
 #'
@@ -190,7 +190,7 @@ close.qpostcon = function(con, ...)
 #' @param filename character string. Name of the file to be opened from the Displayr Cloud Drive.
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #' @param company.token Use this if you need to read from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.
-#' @inheritParams QFileExists params = c("document.token")
+#' @inheritParams QFileExists
 #' @param ... Other parameters to pass to read.csv.
 #'
 #' @return An R object
@@ -386,7 +386,7 @@ QSaveData <- function(object, filename, compression.file.size.threshold = NULL,
 #' @param filenames collection of character strings. Names of the files to delete.
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #' @param company.token Use this if you need to delete files from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.
-#' @inheritParams QFileExists params = c("document.token")
+#' @inheritParams QFileExists
 #'
 #' @importFrom httr DELETE add_headers
 #' @importFrom utils URLencode

--- a/man/QDeleteFiles.Rd
+++ b/man/QDeleteFiles.Rd
@@ -16,7 +16,7 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 
 \item{company.token}{Use this if you need to delete files from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.}
 
-\item{document.token}{Reserved}
+\item{document.token}{Reserved.}
 }
 \value{
 NULL invisibly. Called for the purpose of deleting data

--- a/man/QDeleteFiles.Rd
+++ b/man/QDeleteFiles.Rd
@@ -4,13 +4,19 @@
 \alias{QDeleteFiles}
 \title{Deletes a set of objects}
 \usage{
-QDeleteFiles(filenames, company.token = getCompanySecret())
+QDeleteFiles(
+  filenames,
+  company.token = getCompanySecret(),
+  document.token = getProjectSecret()
+)
 }
 \arguments{
 \item{filenames}{collection of character strings. Names of the files to delete.
 To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").}
 
-\item{company.token}{Use this if you need to read from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.}
+\item{company.token}{Use this if you need to delete files from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.}
+
+\item{document.token}{Reserved}
 }
 \value{
 NULL invisibly. Called for the purpose of deleting data

--- a/man/QFileExists.Rd
+++ b/man/QFileExists.Rd
@@ -4,7 +4,12 @@
 \alias{QFileExists}
 \title{Check if a file exists}
 \usage{
-QFileExists(filename, show.warning = TRUE)
+QFileExists(
+  filename,
+  show.warning = TRUE,
+  company.token = NA,
+  document.token = NA
+)
 }
 \arguments{
 \item{filename}{character string. Name of the file to search for.
@@ -12,6 +17,10 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 
 \item{show.warning}{logical scalar. Whether to show a warning when the file
 does not exist.}
+
+\item{company.token}{Use this if you need to access a different company's Displayr Cloud Drive. You need to contact Support to get this token.}
+
+\item{document.token}{Reserved}
 }
 \value{
 TRUE if the file exists, otherwise FALSE.

--- a/man/QFileExists.Rd
+++ b/man/QFileExists.Rd
@@ -20,7 +20,7 @@ does not exist.}
 
 \item{company.token}{Use this if you need to access a different company's Displayr Cloud Drive. You need to contact Support to get this token.}
 
-\item{document.token}{Reserved}
+\item{document.token}{Reserved.}
 }
 \value{
 TRUE if the file exists, otherwise FALSE.

--- a/man/QFileOpen.Rd
+++ b/man/QFileOpen.Rd
@@ -12,7 +12,8 @@ QFileOpen(
   raw = FALSE,
   method = getOption("url.method", "default"),
   mime.type = NA,
-  company.token = NA
+  company.token = NA,
+  document.token = NA
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 \item{mime.type}{character string. The mime-type of this file. If not provided, it will be interpreted from the file extension.}
 
 \item{company.token}{Use this if you need to read from a different company's Displayr Cloud Drive. You need to contact Support to get this token.}
+
+\item{document.token}{Reserved}
 }
 \value{
 A curl connection (read) or a file connection (write)

--- a/man/QFileOpen.Rd
+++ b/man/QFileOpen.Rd
@@ -34,7 +34,7 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 
 \item{company.token}{Use this if you need to read from a different company's Displayr Cloud Drive. You need to contact Support to get this token.}
 
-\item{document.token}{Reserved}
+\item{document.token}{Reserved.}
 }
 \value{
 A curl connection (read) or a file connection (write)

--- a/man/QLoadData.Rd
+++ b/man/QLoadData.Rd
@@ -12,7 +12,7 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 
 \item{company.token}{Use this if you need to read from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.}
 
-\item{document.token}{Reserved}
+\item{document.token}{Reserved.}
 
 \item{...}{Other parameters to pass to read.csv.}
 }

--- a/man/QLoadData.Rd
+++ b/man/QLoadData.Rd
@@ -4,13 +4,15 @@
 \alias{QLoadData}
 \title{Loads an object}
 \usage{
-QLoadData(filename, company.token = NA, ...)
+QLoadData(filename, company.token = NA, document.token = NA, ...)
 }
 \arguments{
 \item{filename}{character string. Name of the file to be opened from the Displayr Cloud Drive.
 To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").}
 
 \item{company.token}{Use this if you need to read from a different company's Displayr Cloud Drive.  You need to contact Support to get this token.}
+
+\item{document.token}{Reserved}
 
 \item{...}{Other parameters to pass to read.csv.}
 }

--- a/man/QSaveData.Rd
+++ b/man/QSaveData.Rd
@@ -17,7 +17,7 @@ To reference a file in a subdirectory, use double backslashes after each folder 
 Defaults to NULL, in which case no compression occurs.}
 
 \item{...}{Other parameters to pass to \code{\link{write.csv}}, \code{\link{saveRDS}},
-\code{\link{write.xlsx}}, or \code{\link{write_sav}}.}
+\code{\link[openxlsx]{write.xlsx}}, or \code{\link[haven]{write_sav}}.}
 }
 \value{
 NULL invisibly. Called for the purpose of uploading data

--- a/tests/testthat/helper-datamart.R
+++ b/tests/testthat/helper-datamart.R
@@ -1,5 +1,7 @@
 companySecret <- get0("companySecret", ifnotfound = Sys.getenv("companySecret"))
 assign("companySecret", companySecret, envir = .GlobalEnv)
+projectSecret <- ""
+assign("projectSecret", projectSecret, envir = .GlobalEnv)
 clientId <- "-1027046" # This could be anything - we are just using this for metadata
 assign("clientId", clientId, envir = .GlobalEnv)
 region <- "app"

--- a/tests/testthat/helper-datamart.R
+++ b/tests/testthat/helper-datamart.R
@@ -4,3 +4,13 @@ clientId <- "-1027046" # This could be anything - we are just using this for met
 assign("clientId", clientId, envir = .GlobalEnv)
 region <- "app"
 assign("region", region, envir = .GlobalEnv)
+
+localGlobal <- function(name, value, envir = parent.frame()) {
+    if (exists(name, envir = .GlobalEnv)) {
+        old.value <- get(name, envir = .GlobalEnv)
+        withr::defer(assign(name, old.value, envir = .GlobalEnv), envir = envir)
+    } else {
+        withr::defer(rm(list = name, envir = .GlobalEnv), envir = envir)
+    }
+    assign(name, value, envir = .GlobalEnv)
+}

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -1,0 +1,156 @@
+library(testthat)
+library(httr)
+
+
+companySecret <- "test_company_secret"
+assign("companySecret", companySecret, envir = .GlobalEnv)
+
+test_env = new.env()
+
+verifyHttpHeaders <- function(headers = list(), expect_header_to_be_equivalent_to_company_secret) 
+{
+    companySecretHeader = headers["X-Q-Company-Secret"];
+    companySecretHeader <- ifelse(is.null(companySecretHeader), "", companySecretHeader)
+  
+    if (expect_header_to_be_equivalent_to_company_secret && (companySecretHeader != companySecret)) {
+        test_env$headersVerificatoinResult <- list(asExpected = FALSE, 
+            message = paste0("Expected 'companySecretHeader' ('",companySecretHeader,"') to equal 'companySecret' ('", companySecret,"')"))
+    }
+    
+    if (!expect_header_to_be_equivalent_to_company_secret && (companySecretHeader == companySecret)) {
+        test_env$headersVerificatoinResult <- list(asExpected = FALSE, 
+            message = paste0("Expected 'companySecretHeader' ('",companySecretHeader,"') to not equal 'companySecret' ('", companySecret,"')"))
+    }
+    
+    test_env$headersVerificatoinResult <- list(asExpected = TRUE, message = "HTTP headers are as expected")
+    return(structure(list(status_code = 200, content = "mock"), class = "response"))
+}
+
+params <- list(
+    list(company.token = NA, expect_header_to_be_equivalent_to_company_secret = TRUE, description = "company.token is not provided (NA)"),
+    list(company.token = "some_token", expect_header_to_be_equivalent_to_company_secret = FALSE, description = "company.token is some_token"),
+    list(company.token = companySecret, expect_header_to_be_equivalent_to_company_secret = TRUE, description = "company.token is the same as companySecret")
+)
+
+for (p in params){
+    companyTokenParameter = p$company.token
+    clientId <- "1"
+ 
+    mockedHTTPRequest <- function(url = NULL, config = list(), ...) {
+        return(verifyHttpHeaders(config$headers, p$expect_header_to_be_equivalent_to_company_secret))
+    }
+  
+    mockedCloseConnection <- function(con) { }
+  
+    mockedFileExists <- function(filename) { return(FALSE) }
+
+    test_that(paste0("QFileExists correctly passes companySecret and company.token in HTTP header when ", p$description),
+    {
+        test_env$headersVerificatoinResult <- NULL
+
+        with_mocked_bindings(
+            code = {
+                result <- ifelse(is.na(companyTokenParameter), 
+                    QFileExists("Test.dat", show.warning = FALSE),
+                    QFileExists("Test.dat", show.warning = FALSE, company.token = companyTokenParameter))
+
+                expect_true(test_env$headersVerificatoinResult$asExpected, info = test_env$headersVerificatoinResult$message)
+                expect_true(result, info = "QFileExists should return TRUE with mocked GET.")
+            },
+            GET = mockedHTTPRequest,
+            .package = "flipAPI"
+        )
+    })
+
+    test_that(paste0("close.qpostcon correctly passes companySecret and company.token in HTTP header when ", p$description),
+    {
+        test_env$headersVerificatoinResult <- NULL
+      
+        orig_close_connection <- close.connection
+        orig_file_exists <- file.exists
+        on.exit({
+            close.connection <- orig_close_connection
+            file.exists <- orig_file_exists
+        }, add = TRUE)
+        close.connection <- NULL
+        file.exists <- NULL
+
+        with_mocked_bindings(
+            code = {
+                with_mocked_bindings(
+                    code = {
+                        con <- structure(list(url = "http://test/api/DataMart"), class = "connection")
+                        result <- close.qpostcon(con)
+
+                        expect_true(test_env$headersVerificatoinResult$asExpected, info = test_env$headersVerificatoinResult$message)
+                    },
+                    close.connection = mockedCloseConnection,
+                    file.exists = mockedFileExists,
+                    .package = "base"
+                )
+            },
+            POST = mockedHTTPRequest,
+            .package = "flipAPI"
+        )
+    })
+  
+    test_that(paste0("QDeleteFiles correctly passes companySecret and company.token in HTTP header when ", p$description),
+    {
+        test_env$headersVerificatoinResult <- NULL
+
+        with_mocked_bindings(
+            code = {
+                result <- ifelse(is.na(companyTokenParameter), 
+                    QDeleteFiles(c("Test1.dat", "Test2.dat")),
+                    QDeleteFiles(c("Test1.dat", "Test2.dat"), company.token = companyTokenParameter))
+
+                expect_true(test_env$headersVerificatoinResult$asExpected, info = test_env$headersVerificatoinResult$message)
+            },
+            DELETE = mockedHTTPRequest,
+            .package = "flipAPI"
+        )
+    })
+}
+
+test_that("getProjectSecret correctly extract project secret from environment", 
+{
+    projectSecretValueName <- "projectSecret"
+    userSecretsValueName <- "userSecrets"
+    testProjectSecretValue <- "test_project_secret"
+
+    clearProjectSecret <- function () {
+        if (exists(projectSecretValueName, envir = .GlobalEnv)) 
+            rm(list = projectSecretValueName, envir = .GlobalEnv)
+      
+        if (exists(userSecretsValueName, envir = .GlobalEnv)) {
+            userSecrets <- get0(userSecretsValueName, envir = .GlobalEnv)
+            if (projectSecretValueName %in% names(userSecrets)) {
+                userSecrets[[projectSecretValueName]] <- NULL
+                assign(userSecretsValueName, userSecrets, envir = .GlobalEnv)
+            }
+        }
+    }
+  
+    # Case #1: projectSecret is set in environment in projectSecret
+    clearProjectSecret()
+    assign(projectSecretValueName, testProjectSecretValue, envir = .GlobalEnv)
+    expect_equal(getProjectSecret(), testProjectSecretValue)
+  
+    # Case #2: projectSecret is not set in environment in projectSecret, but is set in environment in userSecrets$projectSecret
+    clearProjectSecret()
+    userSecretsValue <- list(projectSecret = testProjectSecretValue)
+    assign(userSecretsValueName, userSecretsValue, envir = .GlobalEnv)
+    expect_equal(getProjectSecret(), testProjectSecretValue)
+  
+    # Case #3: projectSecret is set in both places, getProjectSecret() should prefer projectSecret
+    clearProjectSecret()
+    assign(projectSecretValueName, testProjectSecretValue, envir = .GlobalEnv)
+    userSecretsValue <- list(projectSecret = paste0(testProjectSecretValue, "_different"))
+    assign(userSecretsValueName, userSecretsValue, envir = .GlobalEnv)
+    expect_equal(getProjectSecret(), testProjectSecretValue)
+
+    # Case #4: projectSecret is not set in either place
+    clearProjectSecret()
+    rm(list = userSecretsValueName, envir = .GlobalEnv)
+    expect_equal(getProjectSecret(), "")
+})

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -3,12 +3,10 @@ localGlobal("projectSecret", "test_project_secret")
 
 test_env = new.env() # holds HTTP header verification result that is put there by mocked HTTP function and is used by the tests below
 
-verifyHttpHeaders <- function(headers = list(), expect_company_secret_header_to_be_equivalent_to_company_secret, expect_project_secret_header_to_be_equivalent_to_project_secret) 
+verifyHttpHeaders <- function(headers = character(0), expect_company_secret_header_to_be_equivalent_to_company_secret, expect_project_secret_header_to_be_equivalent_to_project_secret) 
 {
-    companySecretHeader = headers["X-Q-Company-Secret"];
-    companySecretHeader <- ifelse(is.null(companySecretHeader), "", companySecretHeader)
-    projectSecretHeader = headers["X-Q-Project-Secret"];
-    projectSecretHeader <- ifelse(is.null(projectSecretHeader), "", projectSecretHeader)
+    companySecretHeader = headers[["X-Q-Company-Secret"]] %||% ""
+    projectSecretHeader = headers[["X-Q-Project-Secret"]] %||% ""
     httpResponse <- structure(list(status_code = 200, content = "mock"), class = "response")
     companySecret <- getCompanySecret()
     projectSecret <- getProjectSecret()

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -1,25 +1,9 @@
 library(testthat)
 library(httr)
 
-companySecretValueName <- "companySecret"
+localGlobal("companySecret", "test_company_secret")
 
-setup({
-    old_companySecret <- get0(companySecretValueName, envir = .GlobalEnv, ifnotfound = NULL)
-    companySecret <- "test_company_secret"
-    assign(companySecretValueName, companySecret, envir = .GlobalEnv)
-})
-
-teardown({
-    if (exists("old_companySecret", envir = parent.frame())) {
-        assign(companySecretValueName, old_companySecret, envir = .GlobalEnv)
-    } else {
-        if (exists(companySecretValueName, envir = .GlobalEnv)) {
-            rm(list = companySecretValueName, envir = .GlobalEnv)
-        }
-    }
-})
-
-test_env = new.env()
+test_env = new.env() # holds HTTP header verification result that is put there by mocked HTTP function and is used by testthat tests
 
 verifyHttpHeaders <- function(headers = list(), expect_header_to_be_equivalent_to_company_secret) 
 {

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -50,7 +50,7 @@ expect_successful_headers_verification <- function() {
     if (!test_env$headersVerificationResult$asExpected) {
         fail(test_env$headersVerificationResult$messages)
     } else {
-        pass()
+        testthat::pass()
     }
 }
 

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -1,9 +1,23 @@
 library(testthat)
 library(httr)
 
+companySecretValueName <- "companySecret"
 
-companySecret <- "test_company_secret"
-assign("companySecret", companySecret, envir = .GlobalEnv)
+setup({
+    old_companySecret <- get0(companySecretValueName, envir = .GlobalEnv, ifnotfound = NULL)
+    companySecret <- "test_company_secret"
+    assign(companySecretValueName, companySecret, envir = .GlobalEnv)
+})
+
+teardown({
+    if (exists("old_companySecret", envir = parent.frame())) {
+        assign(companySecretValueName, old_companySecret, envir = .GlobalEnv)
+    } else {
+        if (exists(companySecretValueName, envir = .GlobalEnv)) {
+            rm(list = companySecretValueName, envir = .GlobalEnv)
+        }
+    }
+})
 
 test_env = new.env()
 

--- a/tests/testthat/test-datamart-secrets.R
+++ b/tests/testthat/test-datamart-secrets.R
@@ -50,7 +50,7 @@ expect_successful_headers_verification <- function() {
     if (!test_env$headersVerificationResult$asExpected) {
         fail(test_env$headersVerificationResult$messages)
     } else {
-        testthat::pass()
+        expect_true(TRUE)
     }
 }
 


### PR DESCRIPTION
As part of folder permissions project, this PR introduces project secret handling into DataMart API. 
The handling consists of the following.

1. Getting project secret value from the environment or from `document.token` parameter.
2. Passing the project secret to Site DataMart endpoints in `X-Q-Project-Secret` HTTP header.

The project secret value is used in Site to authorize access to DataMart files.

 A note on naming: internally, Displayr Document is called Project and Uploaded Office document is called Document. In user facing UI/text/code Displayr Document is called document. This is why public API parameters introduced in this PR are named `document.token` rather than `project.token`.
