### PR TITLE
PS-1576: Add new QGetSharedUrl method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipAPI
 Type: Package
 Title: Web APIs tools
-Version: 1.6.5
+Version: 1.6.6
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions to extract data and interact with web APIs.

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -382,7 +382,7 @@ QSaveData <- function(object, filename, compression.file.size.threshold = NULL,
 
 #' Share an object
 #'
-#' Get's the cloud drive share url for an object saved to the Displayr Cloud Drive.
+#' Gets the cloud drive share url for an object saved to the Displayr Cloud Drive.
 #'
 #' If the file has not previously been shared it will be shared else the already existing
 #' share url will be returned.
@@ -390,7 +390,7 @@ QSaveData <- function(object, filename, compression.file.size.threshold = NULL,
 #' @param filename character string. Name of the file that is being shared.
 #'   To reference a file in a subdirectory, use double backslashes after each folder (e.g "subdir\\file.csv").
 #'
-#' @importFrom httr POST add_headers upload_file
+#' @importFrom httr POST add_headers content
 #' @importFrom utils URLencode
 #' @return Share URL as a string
 #' @importFrom flipU StopForUserError
@@ -408,24 +408,22 @@ QGetSharedUrl <- function(filename)
                 encode = "raw"))
     has.errored <- inherits(res, "try-error")
 
-    if (!has.errored && res$status_code == 413) # 413 comes from IIS when we violate its web.config limits
-        stopBadRequest(res, "Could not write to Displayr Cloud Drive. Data to write is too large.")
-    else if (!has.errored && res$status_code == 404)
+    if (res$status_code == 404)
     {
-        stop("QSaveData has encountered an unknown error. ",
+        stop("QGetSharedUrl has encountered an unknown error. ",
             "404: No such file exists. ",
             "The likely cause was an incorrect path preceding the filename, or insufficient access to the file path.")
     }
     else if (has.errored || res$status_code != 200)
     {
-        warning("QSaveData has encountered an unknown error.")
+        warning("QGetSharedUrl has encountered an unknown error.")
         stopBadRequest(res, "Could not share file.")
     }
 
     content <- httr::content(res)
     # The content returns a JSON object with the share url in the 'sharingUrl' field
     # and a boolean (that we ignore) that indicates if the file was newly shared or not
-    return (content$sharingUrl)
+    content$sharingUrl
 }
 
 #' Deletes a set of objects

--- a/R/DataMart.R
+++ b/R/DataMart.R
@@ -402,12 +402,10 @@ QGetSharedUrl <- function(filename)
     client.id <- getClientId()
     api.root <- getApiRoot("DataMart/Share")
     res <- try(POST(paste0(api.root, "?filename=", URLencode(filename, TRUE)),
-                config = add_headers("Content-Type" = guess_type(filename),
-                                     "X-Q-Company-Secret" = company.secret,
+                config = add_headers("X-Q-Company-Secret" = company.secret,
                                      "X-Q-Project-Secret" = project.secret,
                                      "X-Q-Project-ID" = client.id),
-                encode = "raw",
-                body = upload_file(tmpfile)))
+                encode = "raw"))
     has.errored <- inherits(res, "try-error")
 
     if (!has.errored && res$status_code == 413) # 413 comes from IIS when we violate its web.config limits


### PR DESCRIPTION
This allows a user to get the shareable url for a given uploaded datamart object.

Very useful when building external reports automatically from Displayr.